### PR TITLE
 Parse recurring detail information

### DIFF
--- a/src/Message/CardResponse.php
+++ b/src/Message/CardResponse.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Adyen\Message;
 
 use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Adyen\RecurringDetailResult;
 
 /**
  * Class CardResponse
@@ -20,11 +21,22 @@ class CardResponse extends AbstractResponse
         return !empty($this->data);
     }
 
+    public function getResult()
+    {
+        return RecurringDetailResult::fromArray($this->data);
+    }
+
     /**
      * Returns the Recurring Detail Reference
      *
      * @return string
      */
+    public function getLastestRecurringDetailReference()
+    {
+        return $this->data['recurringDetailsResult_details_0_recurringDetailReference'];
+    }
+
+
     public function getRecurringDetailReference()
     {
         return $this->data['recurringDetailsResult_details_0_recurringDetailReference'];

--- a/src/RecurringDetail.php
+++ b/src/RecurringDetail.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Omnipay\Adyen;
+
+class RecurringDetail
+{
+    private $adyenResponse;
+
+    public function __construct($adyenResponse)
+    {
+        $this->adyenResponse = $adyenResponse;
+    }
+
+    public function getAdditionalData()
+    {
+        return $this->adyenResponse['additionalData'];
+    }
+
+    public function getCard()
+    {
+        if (isset($this->adyenResponse['card'])) {
+            return $this->adyenResponse['card'];
+        }
+
+        return [];
+    }
+
+    public function getAlias()
+    {
+        return $this->adyenResponse['alias'];
+    }
+
+    public function getAliasType()
+    {
+        return $this->adyenResponse['aliasType'];
+    }
+
+    public function getCreationDate()
+    {
+        return $this->adyenResponse['creationDate'];
+    }
+
+    public function getFirstPspReference()
+    {
+        return $this->adyenResponse['firstPspReference'];
+    }
+
+    public function getPaymentMethodVariant()
+    {
+        return $this->adyenResponse['paymentMethodVariant'];
+    }
+
+    public function getRecurringDetailReference()
+    {
+        return $this->adyenResponse['recurringDetailReference'];
+    }
+
+    public function getVariant()
+    {
+        return $this->adyenResponse['variant'];
+    }
+}

--- a/src/RecurringDetailCollection.php
+++ b/src/RecurringDetailCollection.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Omnipay\Adyen;
+
+class RecurringDetailCollection
+{
+    private $details;
+
+    public function __construct($details)
+    {
+        $this->details = $details;
+    }
+
+    public function getAdditionalData()
+    {
+        return $this->adyenResponse['additionalData'];
+    }
+
+    public function getCardByNumber($number)
+    {
+        foreach($this->details as $recurringDetail) {
+            $card = $recurringDetail->getCard();
+            if ($card['number'] == $number) {
+                return $card;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/RecurringDetailResult.php
+++ b/src/RecurringDetailResult.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Omnipay\Adyen;
+
+class RecurringDetailResult
+{
+    private $parsedData = [];
+
+    public function __construct($parsedData)
+    {
+        $this->parsedData = $parsedData;
+    }
+
+    public static function fromArray($dataToParse)
+    {
+        $parsedData = [];
+        foreach ($dataToParse as $key => $value) {
+            $parsedData = self::parseRecurringDetailsResult($key, $parsedData, $value);
+        }
+
+        return new RecurringDetailResult($parsedData['recurringDetailsResult']);
+    }
+
+    public function getDetails()
+    {
+        return new RecurringDetailCollection($this->parsedData['details']);
+    }
+
+    public function getCreationDate()
+    {
+        return $this->parsedData['creationDate'];
+    }
+
+    public function getLastKnownShopperEmail()
+    {
+        return $this->parsedData['lastKnownShopperEmail'];
+    }
+
+    public function getShopperReference()
+    {
+        return $this->parsedData['shopperReference'];
+    }
+
+    private static function parseRecurringDetailsResult($key, $hash, $value)
+    {
+        $explodeResult = explode('_', $key, 2);
+
+        if (count($explodeResult) == 1) {
+            $hash[$explodeResult[0]] = $value;
+        } else {
+            list($first, $rest) = $explodeResult;
+            $hash[$first] = self::parseRecurringDetailsResult(
+                $rest,
+                isset($hash[$first]) ? $hash[$first] : [],
+                $value
+            );
+        }
+
+        return $hash;
+    }
+}

--- a/tests/RecurringDetailCollectionTest.php
+++ b/tests/RecurringDetailCollectionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Omnipay\Adyen;
+
+use PHPUnit\Framework\TestCase;
+
+class RecurringDetailCollectionTest extends TestCase
+{
+    private $recurringDetailCollection;
+
+    public function setUp()
+    {
+        $this->recurringDetailCollection = new RecurringDetailCollection([
+            new RecurringDetail([
+                'card' => [
+                    'expiryMonth' => '10',
+                    'expiryYear' => '2021',
+                    'holderName' => 'Easy taxi',
+                    'number' => '1407'
+                ],
+                'creationDate' => '2017-11-23T16:28:27+01:00'
+            ]),
+            new RecurringDetail([
+                'card' => [
+                    'expiryMonth' => '10',
+                    'expiryYear' => '2021',
+                    'holderName' => 'Easy taxi',
+                    'number' => '1407'
+                ],
+                'creationDate' => '2017-11-23T16:28:27+01:00'
+            ])
+        ]);
+    }
+
+    public function testGetCardByNumber()
+    {
+        $number = '1407';
+        $this->assertEquals(
+            $this->recurringDetailCollection->getCardByNumber($number),
+            [
+                'expiryMonth' => '10',
+                'expiryYear' => '2021',
+                'holderName' => 'Easy taxi',
+                'number' => '1407'
+            ]
+        );
+    }
+}

--- a/tests/RecurringDetailResultTest.php
+++ b/tests/RecurringDetailResultTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Omnipay\Adyen;
+
+use PHPUnit\Framework\TestCase;
+
+class RecurringDetailResultTest extends TestCase
+{
+    private $adyenApiResponse;
+    private $parsedAdyenApiResponse;
+
+    public function setUp()
+    {
+        $this->adyenApiResponse = [
+            'recurringDetailsResult_creationDate' => '2017-11-23T16:28:27+01:00',
+            'recurringDetailsResult_details_0_additionalData_cardBin' => '530551',
+            'recurringDetailsResult_details_0_alias' => '09876543321123456',
+            'recurringDetailsResult_details_0_aliasType' => 'Default',
+            'recurringDetailsResult_details_0_card_expiryMonth' => '10',
+            'recurringDetailsResult_details_0_card_expiryYear' => '2021',
+            'recurringDetailsResult_details_0_card_holderName' => 'Easy taxi',
+            'recurringDetailsResult_details_0_card_number' => '1407',
+            'recurringDetailsResult_details_0_creationDate' => '2017-11-23T16:28:27+01:00',
+            'recurringDetailsResult_details_0_firstPspReference' => 'asdfghjkl1234567',
+            'recurringDetailsResult_details_0_paymentMethodVariant' => 'mccredit',
+            'recurringDetailsResult_details_0_recurringDetailReference' => '1234567890123456',
+            'recurringDetailsResult_details_0_variant' => 'mc',
+            'recurringDetailsResult_lastKnownShopperEmail' => 'p@easytaxi.com.br',
+            'recurringDetailsResult_shopperReference' => '123456789012345678901234'
+        ];
+
+        $this->parsedAdyenApiResponse =[
+            "creationDate" => "2017-11-23T16:28:27+01:00",
+            "details" => [
+                [
+                    "additionalData" => [
+                        "cardBin" => "530551"
+                    ],
+                    "alias" => "09876543321123456",
+                    "aliasType" => "Default",
+                    "card" => [
+                        "expiryMonth" => "10",
+                        "expiryYear" => "2021",
+                        "holderName" => "Easy taxi",
+                        "number" => "1407"
+                    ],
+                    "creationDate" => "2017-11-23T16:28:27+01:00",
+                    "firstPspReference" => "asdfghjkl1234567",
+                    "paymentMethodVariant" => "mccredit",
+                    "recurringDetailReference" => "1234567890123456",
+                    "variant" => "mc"
+                ]
+            ],
+            "lastKnownShopperEmail" => "p@easytaxi.com.br",
+            "shopperReference" => "123456789012345678901234"
+        ];
+    }
+
+    public function testConstructFromArray()
+    {
+        $this->assertEquals(
+            RecurringDetailResult::fromArray($this->adyenApiResponse),
+            new RecurringDetailResult($this->parsedAdyenApiResponse)
+        );
+    }
+
+    public function testGetCreationDate()
+    {
+        $recurringDetail = RecurringDetailResult::fromArray($this->adyenApiResponse);
+        $this->assertEquals(
+            $recurringDetail->getCreationDate(),
+            "2017-11-23T16:28:27+01:00"
+        );
+    }
+
+    public function testGetLastKnownShopperEmail()
+    {
+        $recurringDetail = RecurringDetailResult::fromArray($this->adyenApiResponse);
+        $this->assertEquals(
+            $recurringDetail->getLastKnownShopperEmail(),
+            "p@easytaxi.com.br"
+        );
+    }
+
+    public function testGetShopperReference()
+    {
+        $recurringDetail = RecurringDetailResult::fromArray($this->adyenApiResponse);
+        $this->assertEquals(
+            $recurringDetail->getShopperReference(),
+            "123456789012345678901234"
+        );
+    }
+}

--- a/tests/RecurringDetailTest.php
+++ b/tests/RecurringDetailTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Omnipay\Adyen;
+
+use PHPUnit\Framework\TestCase;
+
+class RecurringDetailTest extends TestCase
+{
+    private $recurringDetail;
+
+    public function setUp()
+    {
+        $this->recurringDetail = new RecurringDetail($this->adyenResponse());
+    }
+
+    private function adyenResponse()
+    {
+        return [
+            'additionalData' => ['cardBin' => '530551'],
+            'alias' => '1234567890098765',
+            'aliasType' => 'Default',
+            'card' => [
+                'expiryMonth' => '10',
+                'expiryYear' => '2021',
+                'holderName' => 'Easy taxi',
+                'number' => '1407'
+            ],
+            'creationDate' => '2017-11-23T16:28:27+01:00',
+            'firstPspReference' => 'asdfghjkl1234567',
+            'paymentMethodVariant' => 'mccredit',
+            'recurringDetailReference' => '1234567890123456',
+            'variant' => 'mc'
+        ];
+    }
+
+    public function testGetAdditionalData()
+    {
+        $this->assertEquals(
+            $this->recurringDetail->getAdditionalData(),
+            ['cardBin' => '530551']
+        );
+    }
+
+    public function testGetCard()
+    {
+        $this->assertEquals(
+            $this->recurringDetail->getCard(),
+            [
+                'expiryMonth' => '10',
+                'expiryYear' => '2021',
+                'holderName' => 'Easy taxi',
+                'number' => '1407'
+            ]
+        );
+    }
+
+    public function testGetCardWhenUserHasNoCardRegistered()
+    {
+        $adyenResponseWithNoCards = $this->adyenResponse();
+        unset($adyenResponseWithNoCards['card']);
+
+        $recurringDetail = new RecurringDetail($adyenResponseWithNoCards);
+        $this->assertEquals(
+            $recurringDetail->getCard(),
+            []
+        );
+    }
+
+    public function testGetAlias()
+    {
+        $this->assertEquals($this->recurringDetail->getAlias(), '1234567890098765');
+    }
+
+    public function testGetAliasType()
+    {
+        $this->assertEquals($this->recurringDetail->getAliasType(), 'Default');
+    }
+
+    public function testGetCreationDate()
+    {
+        $this->assertEquals($this->recurringDetail->getCreationDate(), '2017-11-23T16:28:27+01:00');
+    }
+
+    public function testFirstPspReference()
+    {
+        $this->assertEquals($this->recurringDetail->getFirstPspReference(), 'asdfghjkl1234567');
+    }
+
+    public function testGetPaymentMethodVariant()
+    {
+        $this->assertEquals($this->recurringDetail->getPaymentMethodVariant(), 'mccredit');
+    }
+
+    public function testGetRecurringDetailReference()
+    {
+        $this->assertEquals($this->recurringDetail->getRecurringDetailReference(), '1234567890123456');
+    }
+
+    public function testGetVariant()
+    {
+        $this->assertEquals($this->recurringDetail->getVariant(), 'mc');
+    }
+
+}


### PR DESCRIPTION
Until now, the lib was only parsing the recurring detail with index 0,
this commit parses all recurring details and it's fields.

For backward compatibility we keep the the method
`getRecurringDetailReference` which reads only one card, but in the next
major version we could think about removing it.