### PR TITLE
Make RecurringDeatailCollection to work with list objects instead array

### DIFF
--- a/src/RecurringDetailCollection.php
+++ b/src/RecurringDetailCollection.php
@@ -6,22 +6,17 @@ class RecurringDetailCollection
 {
     private $details;
 
-    public function __construct($details)
+    public function add(RecurringDetail $recurringDetail)
     {
-        $this->details = $details;
+         $this->details[] = $recurringDetail;
     }
 
-    public function getAdditionalData()
-    {
-        return $this->adyenResponse['additionalData'];
-    }
-
-    public function getCardByNumber($number)
+    public function getByCardNumber($number)
     {
         foreach($this->details as $recurringDetail) {
             $card = $recurringDetail->getCard();
             if ($card['number'] == $number) {
-                return $card;
+                return $recurringDetail;
             }
         }
 

--- a/src/RecurringDetailResult.php
+++ b/src/RecurringDetailResult.php
@@ -23,7 +23,15 @@ class RecurringDetailResult
 
     public function getDetails()
     {
-        return new RecurringDetailCollection($this->parsedData['details']);
+        $recurringDetailCollection = new RecurringDetailCollection();
+
+        foreach ($this->parsedData['details'] as $detail) {
+            $recurringDetailCollection->add(
+                new RecurringDetail($detail)
+            );
+        }
+
+        return $recurringDetailCollection;
     }
 
     public function getCreationDate()

--- a/tests/RecurringDetailCollectionTest.php
+++ b/tests/RecurringDetailCollectionTest.php
@@ -10,39 +10,54 @@ class RecurringDetailCollectionTest extends TestCase
 
     public function setUp()
     {
-        $this->recurringDetailCollection = new RecurringDetailCollection([
-            new RecurringDetail([
-                'card' => [
-                    'expiryMonth' => '10',
-                    'expiryYear' => '2021',
-                    'holderName' => 'Easy taxi',
-                    'number' => '1407'
-                ],
-                'creationDate' => '2017-11-23T16:28:27+01:00'
-            ]),
-            new RecurringDetail([
-                'card' => [
-                    'expiryMonth' => '10',
-                    'expiryYear' => '2021',
-                    'holderName' => 'Easy taxi',
-                    'number' => '1407'
-                ],
-                'creationDate' => '2017-11-23T16:28:27+01:00'
-            ])
-        ]);
+        $this->recurringDetailCollection = new RecurringDetailCollection();
+        $this->recurringDetailCollection->add(
+            new RecurringDetail(
+                [
+                    'card' => [
+                        'expiryMonth' => '10',
+                        'expiryYear' => '2021',
+                        'holderName' => 'Easy taxi',
+                        'number' => '1407'
+                    ],
+                    'creationDate' => '2017-11-23T16:28:27+01:00'
+                ]
+            )
+        );
+
+        $this->recurringDetailCollection->add(
+            new RecurringDetail(
+                [
+                    'card' => [
+                        'expiryMonth' => '10',
+                        'expiryYear' => '2021',
+                        'holderName' => 'Easy taxi',
+                        'number' => '1407'
+                    ],
+                    'creationDate' => '2017-11-23T16:28:27+01:00'
+                ]
+            )
+        );
     }
 
-    public function testGetCardByNumber()
+    public function testGetByCardNumber()
     {
         $number = '1407';
-        $this->assertEquals(
-            $this->recurringDetailCollection->getCardByNumber($number),
+        $recurringDetail = new RecurringDetail(
             [
-                'expiryMonth' => '10',
-                'expiryYear' => '2021',
-                'holderName' => 'Easy taxi',
-                'number' => '1407'
+                'card' => [
+                    'expiryMonth' => '10',
+                    'expiryYear' => '2021',
+                    'holderName' => 'Easy taxi',
+                    'number' => '1407'
+                ],
+                'creationDate' => '2017-11-23T16:28:27+01:00'
             ]
+        );
+
+        $this->assertEquals(
+            $this->recurringDetailCollection->getByCardNumber($number),
+            $recurringDetail
         );
     }
 }


### PR DESCRIPTION
Currently in RecurringDetailCollection the $details are a
list of arrays.

This update parse the recurring detail array to a
RecrurringDetail object and now the RecurringDetailCollection
have a list of RecurringDetail.